### PR TITLE
Window background

### DIFF
--- a/crates/collab_ui/src/collab_ui.rs
+++ b/crates/collab_ui/src/collab_ui.rs
@@ -13,8 +13,7 @@ use call::{report_call_event_for_room, ActiveCall};
 pub use collab_panel::CollabPanel;
 pub use collab_titlebar_item::CollabTitlebarItem;
 use gpui::{
-    actions, point, AppContext, GlobalPixels, Pixels, PlatformDisplay, Size, Task, WindowContext,
-    WindowKind, WindowOptions,
+    actions, point, AppContext, GlobalPixels, Pixels, PlatformDisplay, Size, Task, WindowBackground, WindowContext, WindowKind, WindowOptions
 };
 use panel_settings::MessageEditorSettings;
 pub use panel_settings::{
@@ -121,5 +120,6 @@ fn notification_window_options(
         is_movable: false,
         display_id: Some(screen.id()),
         fullscreen: false,
+        window_background: Some(WindowBackground::default())
     }
 }

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -531,6 +531,9 @@ pub struct WindowOptions {
 
     /// The display to create the window on
     pub display_id: Option<DisplayId>,
+
+    /// The background type of the window
+    pub window_background: Option<WindowBackground>
 }
 
 /// The variables that can be configured when creating a new window
@@ -554,6 +557,8 @@ pub(crate) struct WindowParams {
 
     /// The display to create the window on
     pub display_id: Option<DisplayId>,
+
+    pub window_background: Option<WindowBackground>
 }
 
 impl Default for WindowOptions {
@@ -571,6 +576,7 @@ impl Default for WindowOptions {
             is_movable: true,
             display_id: None,
             fullscreen: false,
+            window_background: Some(WindowBackground::default()),
         }
     }
 }

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -487,6 +487,7 @@ impl MacWindow {
     pub fn open(
         handle: AnyWindowHandle,
         WindowParams {
+            window_background,
             bounds,
             titlebar,
             kind,
@@ -498,6 +499,7 @@ impl MacWindow {
         executor: ForegroundExecutor,
         renderer_context: renderer::Context,
     ) -> Self {
+
         unsafe {
             let pool = NSAutoreleasePool::new(nil);
 
@@ -572,7 +574,7 @@ impl MacWindow {
                 size(bounds.size.width.0 * scale, bounds.size.height.0 * scale)
             };
 
-            let window = Self(Arc::new(Mutex::new(MacWindowState {
+            let mut window = Self(Arc::new(Mutex::new(MacWindowState {
                 handle,
                 executor,
                 native_window,
@@ -648,6 +650,11 @@ impl MacWindow {
 
             native_window.setContentView_(native_view.autorelease());
             native_window.makeFirstResponder_(native_view);
+
+
+            if window_background.is_some() {
+                window.set_background(window_background.unwrap());
+            }
 
             match kind {
                 WindowKind::Normal => {

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -397,6 +397,7 @@ impl Window {
             is_movable,
             display_id,
             fullscreen,
+            window_background
         } = options;
 
         let bounds = bounds.unwrap_or_else(|| default_bounds(cx));
@@ -410,6 +411,7 @@ impl Window {
                 focus,
                 show,
                 display_id,
+                window_background
             },
         );
         let display_id = platform_window.display().id();

--- a/crates/theme_importer/src/vscode/converter.rs
+++ b/crates/theme_importer/src/vscode/converter.rs
@@ -55,6 +55,7 @@ impl VsCodeThemeConverter {
         Ok(ThemeContent {
             name: self.theme_metadata.name,
             appearance,
+            window_background: Some(String::from("opaque")),
             style: ThemeStyleContent {
                 colors: theme_colors,
                 status: status_colors,

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -28,6 +28,7 @@ use settings::{
     initial_local_settings_content, initial_tasks_content, watch_config_file, KeymapFile, Settings,
     SettingsStore, DEFAULT_KEYMAP_PATH,
 };
+use theme::ActiveTheme;
 use std::{borrow::Cow, ops::Deref, path::Path, sync::Arc};
 use task::{
     oneshot_source::OneshotSource,
@@ -102,6 +103,7 @@ pub fn build_window_options(display_uuid: Option<Uuid>, cx: &mut AppContext) -> 
         is_movable: true,
         display_id: display.map(|display| display.id()),
         fullscreen: false,
+        window_background: Some(cx.theme().window_background()) 
     }
 }
 


### PR DESCRIPTION
- Added `window_background` as an property to `WindowOptions` and `WindowParams`. 
- - This makes the call for any new windows easier, since they all make the default window options on the function `build_window_options` on `zed.rs` at the zed crate, which can retrieve the current window background from the theme applied by the user.


- Added `window_background: Some(String::from("opaque"))` at the `converter.rs` on the `theme_importer` crate.